### PR TITLE
Explain epoch `link`

### DIFF
--- a/docs/integration-guides/the-basics.md
+++ b/docs/integration-guides/the-basics.md
@@ -162,6 +162,7 @@ Depending on the action each transaction intends to perform, the `"link"` field 
 | Change  | decimal string     | Must be "0"                                |
 | Send    | 64 hex-char string | Public key for destination account         |
 | Receive | 64 hex-char string | Pairing block's hash (block sending funds) |
+| Epoch   | 64 hex-char string | ASCII "epoch v1 block" or "epoch v2 block" |
 
  If using the [block_create](/commands/rpc-protocol#block_create) RPC command the optional fields `"source"` (with the block hash to be received) and `"destination"` (with the target `nano_` address) fields can be used instead of directly defining the `"link"` field.
 


### PR DESCRIPTION
Updated integration guide "The Basics" to add brief meaning of `link` in epoch blocks. Text summarized from comment in header file: https://github.com/nanocurrency/nano-node/blob/develop/nano/lib/epochs.hpp

```
/** Returns true if link matches one of the released epoch links.
 *  WARNING: just because a legal block contains an epoch link, it does not mean it is an epoch block.
 *  A legal block containing an epoch link can easily be constructed by sending to an address identical
 *  to one of the epoch links.
 *  Epoch blocks follow the following rules and a block must satisfy them all to be a true epoch block:
 *    epoch blocks are always state blocks
 *    epoch blocks never change the balance of an account
 *    epoch blocks always have a link field that starts with the ascii bytes "epoch v1 block" or "epoch v2 block" (and possibly others in the future)
 *    epoch blocks never change the representative
 *    epoch blocks are not signed by the account key, they are signed either by genesis or by special epoch keys
 */
```